### PR TITLE
Rename command to git-dg

### DIFF
--- a/Formula/dgit.rb
+++ b/Formula/dgit.rb
@@ -36,7 +36,7 @@ class Dgit < Formula
     system "make", "install"
 
     bin.install "#{ENV["GOPATH"]}/bin/git-dg"
-    bin.install "#{ENV["GOPATH"]}/bin/git-remote-dgit"
+    bin.install "#{ENV["GOPATH"]}/bin/git-remote-dg"
 
     ohai "dgit has been renamed decentragit and is now invoked via git with `git dg [command]`."
   end

--- a/Formula/dgit.rb
+++ b/Formula/dgit.rb
@@ -35,11 +35,11 @@ class Dgit < Formula
 
     system "make", "install"
 
-    bin.install "#{ENV["GOPATH"]}/bin/dgit"
+    bin.install "#{ENV["GOPATH"]}/bin/git-dg"
     bin.install "#{ENV["GOPATH"]}/bin/git-remote-dgit"
   end
 
   test do
-    system "#{bin}/dgit"
+    system "#{bin}/git-dg"
   end
 end

--- a/Formula/dgit.rb
+++ b/Formula/dgit.rb
@@ -37,6 +37,8 @@ class Dgit < Formula
 
     bin.install "#{ENV["GOPATH"]}/bin/git-dg"
     bin.install "#{ENV["GOPATH"]}/bin/git-remote-dgit"
+
+    ohai "dgit has been renamed decentragit and is now invoked via git with `git dg [command]`."
   end
 
   test do


### PR DESCRIPTION
Companion PR to https://github.com/quorumcontrol/dgit/pull/74 to handle the rename. I guess we should have it delete it the old `dgit` file too if it exists? Or maybe Homebrew does that for us?